### PR TITLE
http adapter - removed empty js/ts switch

### DIFF
--- a/content/faq/http-adapter.md
+++ b/content/faq/http-adapter.md
@@ -9,7 +9,6 @@ Basically, every native (platform-specific) HTTP server/library instance is wrap
 In order to get the `HttpAdapter` from the outside of the application context, you can call `getHttpAdapter()` method.
 
 ```typescript
-@@filename()
 const app = await NestFactory.create(ApplicationModule);
 const httpAdapter = app.getHttpAdapter();
 ```


### PR DESCRIPTION
Having the `@@filename()` command without the `@@switch` to javascript code adds an empty header above the source code.
Since there is no switch, I removed it to remove the wasted vertical space

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information